### PR TITLE
Describe how to boot into XFCE/LXDE in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ or LXDE
     PREFERRED=lxsession
     EOF   
 
+If you want to boot into the graphical desktop that you have configured.
+
+    systemctl set-default graphical.target
+
 Building your own u-boot
 --------------
     git clone https://github.com/rabeeh/u-boot-imx6.git


### PR DESCRIPTION
The README misses the step that makes systemd boot into graphical mode by default.